### PR TITLE
Add login spinner

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,3 @@
 github "Alamofire/Alamofire" ~> 3.3
 github "square/SocketRocket"
+github "jdg/MBProgressHUD"

--- a/TraccarManager.xcodeproj/project.pbxproj
+++ b/TraccarManager.xcodeproj/project.pbxproj
@@ -563,8 +563,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"$(PROJECT_DIR)/Carthage/Checkouts/MBProgressHUD/Carthage/Build/iOS",
-					"$(PROJECT_DIR)/Carthage/Checkouts/MBProgressHUD/Carthage/Build/Mac",
 				);
 				INFOPLIST_FILE = TraccarManager/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -582,8 +580,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"$(PROJECT_DIR)/Carthage/Checkouts/MBProgressHUD/Carthage/Build/iOS",
-					"$(PROJECT_DIR)/Carthage/Checkouts/MBProgressHUD/Carthage/Build/Mac",
 				);
 				INFOPLIST_FILE = TraccarManager/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/TraccarManager.xcodeproj/project.pbxproj
+++ b/TraccarManager.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		D3091CAB1CDDE2900017F0DC /* Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3091CA81CDDE2900017F0DC /* Position.swift */; };
 		D3091CBF1CDEAED10017F0DC /* DeviceInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3091CBE1CDEAED10017F0DC /* DeviceInfoViewController.swift */; };
 		D30ACDB71CE5409700925366 /* Main-iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D30ACDB51CE5409700925366 /* Main-iPad.storyboard */; };
+		D30ACDFD1CE5DE2E00925366 /* MBProgressHUD.m in Sources */ = {isa = PBXBuildFile; fileRef = D30ACDE11CE5DE2E00925366 /* MBProgressHUD.m */; };
 		D3394F261CE1C77900795822 /* PositionAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3394F251CE1C77900795822 /* PositionAnnotation.swift */; };
 		D3394F271CE1C77900795822 /* PositionAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3394F251CE1C77900795822 /* PositionAnnotation.swift */; };
 		D3394F281CE1C77900795822 /* PositionAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3394F251CE1C77900795822 /* PositionAnnotation.swift */; };
@@ -98,6 +99,9 @@
 		D3091CA81CDDE2900017F0DC /* Position.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Position.swift; sourceTree = "<group>"; };
 		D3091CBE1CDEAED10017F0DC /* DeviceInfoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceInfoViewController.swift; sourceTree = "<group>"; };
 		D30ACDB61CE5409700925366 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = "Base.lproj/Main-iPad.storyboard"; sourceTree = "<group>"; };
+		D30ACDE01CE5DE2E00925366 /* MBProgressHUD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBProgressHUD.h; sourceTree = "<group>"; };
+		D30ACDE11CE5DE2E00925366 /* MBProgressHUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBProgressHUD.m; sourceTree = "<group>"; };
+		D30ACE041CE5DE7300925366 /* BridgingHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BridgingHeader.h; path = TraccarManager/BridgingHeader.h; sourceTree = "<group>"; };
 		D3394F251CE1C77900795822 /* PositionAnnotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PositionAnnotation.swift; sourceTree = "<group>"; };
 		D3394F341CE2A56600795822 /* Definitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Definitions.swift; sourceTree = "<group>"; };
 		D3394F381CE3D0AD00795822 /* SocketRocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SocketRocket.framework; path = Carthage/Build/iOS/SocketRocket.framework; sourceTree = "<group>"; };
@@ -149,11 +153,13 @@
 		CE0721061C86EB9800D057CE = {
 			isa = PBXGroup;
 			children = (
+				D30ACE041CE5DE7300925366 /* BridgingHeader.h */,
 				CE0721111C86EB9800D057CE /* TraccarManager */,
 				CE0721261C86EB9800D057CE /* TraccarManagerTests */,
 				CE0721311C86EB9800D057CE /* TraccarManagerUITests */,
 				CE0721101C86EB9800D057CE /* Products */,
 				C47A9C561CBDCB24F2866BD2 /* Frameworks */,
+				D30ACDB81CE5DE2E00925366 /* MBProgressHUD */,
 			);
 			sourceTree = "<group>";
 		};
@@ -215,6 +221,16 @@
 				D3091CA81CDDE2900017F0DC /* Position.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		D30ACDB81CE5DE2E00925366 /* MBProgressHUD */ = {
+			isa = PBXGroup;
+			children = (
+				D30ACDE01CE5DE2E00925366 /* MBProgressHUD.h */,
+				D30ACDE11CE5DE2E00925366 /* MBProgressHUD.m */,
+			);
+			name = MBProgressHUD;
+			path = Carthage/Checkouts/MBProgressHUD;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -381,6 +397,7 @@
 				D3091CA91CDDE2900017F0DC /* Position.swift in Sources */,
 				CEE848D41CCDCF0E000B1E9D /* DevicesViewController.swift in Sources */,
 				D3394F261CE1C77900795822 /* PositionAnnotation.swift in Sources */,
+				D30ACDFD1CE5DE2E00925366 /* MBProgressHUD.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -546,11 +563,14 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Checkouts/MBProgressHUD/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Checkouts/MBProgressHUD/Carthage/Build/Mac",
 				);
 				INFOPLIST_FILE = TraccarManager/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.traccar.TraccarManager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = TraccarManager/BridgingHeader.h;
 			};
 			name = Debug;
 		};
@@ -562,11 +582,14 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Checkouts/MBProgressHUD/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Checkouts/MBProgressHUD/Carthage/Build/Mac",
 				);
 				INFOPLIST_FILE = TraccarManager/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.traccar.TraccarManager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = TraccarManager/BridgingHeader.h;
 			};
 			name = Release;
 		};

--- a/TraccarManager/AppDelegate.swift
+++ b/TraccarManager/AppDelegate.swift
@@ -16,7 +16,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         
-        WebService.sharedInstance.reconnectWebSocket()
+        if User.sharedInstance.isAuthenticated {
+            WebService.sharedInstance.reconnectWebSocket()
+        }
         
         return true
     }

--- a/TraccarManager/BridgingHeader.h
+++ b/TraccarManager/BridgingHeader.h
@@ -1,0 +1,14 @@
+//
+//  BridgingHeader.h
+//  TraccarManager
+//
+//  Created by William Pearse on 13/05/16.
+//  Copyright © 2016 Anton Tananaev. All rights reserved.
+//
+
+#ifndef BridgingHeader_h
+#define BridgingHeader_h
+
+#import "MBProgressHud.h"
+
+#endif /* BridgingHeader_h */

--- a/TraccarManager/DevicesViewController.swift
+++ b/TraccarManager/DevicesViewController.swift
@@ -15,7 +15,13 @@ class DevicesViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // update the map when we're told that a Position has been updated
+        // update the list when we're told that a Position has been updated (this is the "Updated ... ago" message)
+        NSNotificationCenter.defaultCenter().addObserver(self,
+                                                         selector: #selector(DevicesViewController.reloadDevices),
+                                                         name: Definitions.PositionUpdateNotificationName,
+                                                         object: nil)
+        
+        // update the list when a Device has been updated (maybe the name has changed, or an addition/removal of a device)
         NSNotificationCenter.defaultCenter().addObserver(self,
                                                          selector: #selector(DevicesViewController.reloadDevices),
                                                          name: Definitions.DeviceUpdateNotificationName,

--- a/TraccarManager/LoginViewController.swift
+++ b/TraccarManager/LoginViewController.swift
@@ -43,22 +43,35 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     }
 
     @IBAction func loginButtonPressed() {
+        
+        MBProgressHUD.showHUDAddedTo(view, animated: true)
+        
         WebService.sharedInstance.authenticate(serverField!.text!, email: emailField!.text!, password: passwordField!.text!, onFailure: { errorString in
             
-                let ac = UIAlertController(title: "Couldn't Login", message: errorString, preferredStyle: .Alert)
-                let okAction = UIAlertAction(title: "OK", style: .Default, handler: nil)
-                ac.addAction(okAction)
-                self.presentViewController(ac, animated: true, completion: nil)
+                dispatch_async(dispatch_get_main_queue(), {
+                    
+                    MBProgressHUD.hideHUDForView(self.view, animated: true)
+                    
+                    let ac = UIAlertController(title: "Couldn't Login", message: errorString, preferredStyle: .Alert)
+                    let okAction = UIAlertAction(title: "OK", style: .Default, handler: nil)
+                    ac.addAction(okAction)
+                    self.presentViewController(ac, animated: true, completion: nil)
+                })
             
             }, onSuccess: { (user) in
                 
-                // save server, user
-                let d = NSUserDefaults.standardUserDefaults()
-                d.setValue(self.serverField!.text!, forKey: TCDefaultsServerKey)
-                d.setValue(self.emailField!.text!, forKey: TCDefaultsEmailKey)
-                d.synchronize()
+                dispatch_async(dispatch_get_main_queue(), {
                 
-                self.dismissViewControllerAnimated(true, completion: nil)
+                    // save server, user
+                    let d = NSUserDefaults.standardUserDefaults()
+                    d.setValue(self.serverField!.text!, forKey: TCDefaultsServerKey)
+                    d.setValue(self.emailField!.text!, forKey: TCDefaultsEmailKey)
+                    d.synchronize()
+                    
+                    MBProgressHUD.hideHUDForView(self.view, animated: true)
+                
+                    self.dismissViewControllerAnimated(true, completion: nil)
+                })
             }
         )
     }


### PR DESCRIPTION
This PR:
- Adds login spinner (closes #15). MBProgressHUD is robust and widely used, but unfortunately is ObjC, so requires the addition of a bridging header.
- Only reconnect web socket on app launch if user is authenticated
- Waits 10 seconds before reconnecting web socket on failure (prevents crazy fail-reconnect-fail-reconnect-fail... cycle)
